### PR TITLE
Fixes issue with packet construction

### DIFF
--- a/r-lanlib/src/network.rs
+++ b/r-lanlib/src/network.rs
@@ -76,8 +76,9 @@ pub fn get_available_port() -> Result<u16, io::Error> {
 
 fn get_interface_ipv4_and_cidr(interface: &PNetNetworkInterface) -> Option<(String, String)> {
     let ipnet = interface.ips.iter().find(|i| i.is_ipv4())?;
-    let ip = ipnet.network().to_string();
+    let ip = ipnet.ip().to_string();
+    let base = ipnet.network().to_string();
     let prefix = ipnet.prefix().to_string();
-    let cidr = String::from(format!("{ip}/{prefix}"));
+    let cidr = String::from(format!("{base}/{prefix}"));
     Some((ip, cidr))
 }

--- a/r-lanlib/src/packet.rs
+++ b/r-lanlib/src/packet.rs
@@ -5,7 +5,7 @@ pub mod syn;
 pub mod wire;
 
 /// Default timing for throttling packet sends to prevent packet loss
-pub const DEFAULT_PACKET_SEND_TIMING: time::Duration = time::Duration::from_micros(100);
+pub const DEFAULT_PACKET_SEND_TIMING: time::Duration = time::Duration::from_micros(10);
 
 pub trait Reader: Send + Sync {
     fn next_packet(&mut self) -> Result<&[u8], std::io::Error>;

--- a/r-lanscan/src/main.rs
+++ b/r-lanscan/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
 
     /// Perform reverse dns lookups
     #[arg(long, default_value_t = false)]
-    dns: bool,
+    host_names: bool,
 
     /// Set idle timeout in milliseconds for all scanners
     #[arg(long, default_value_t = IDLE_TIMEOUT)]
@@ -92,17 +92,19 @@ fn initialize_logger(args: &Args) {
     .unwrap();
 }
 
-fn print_args(args: &Args) {
+fn print_args(args: &Args, interface: &NetworkInterface) {
     info!("configuration:");
     info!("targets:         {:?}", args.targets);
     info!("ports            {:?}", args.ports);
     info!("json:            {}", args.json);
     info!("arpOnly:         {}", args.arp_only);
     info!("vendor:          {}", args.vendor);
-    info!("dns:             {}", args.dns);
+    info!("host_names:      {}", args.host_names);
     info!("quiet:           {}", args.quiet);
     info!("idle_timeout_ms: {}", args.idle_timeout_ms);
-    info!("interface:       {}", args.interface);
+    info!("interface:       {}", interface.name);
+    info!("cidr:            {}", interface.cidr);
+    info!("user_ip:         {}", interface.ipv4.to_string());
     info!("source_port:     {}", args.source_port);
 }
 
@@ -122,7 +124,7 @@ fn process_arp(
         packet_sender,
         IPTargets::new(args.targets.clone()),
         args.vendor,
-        args.dns,
+        args.host_names,
         time::Duration::from_millis(args.idle_timeout_ms.into()),
         tx,
     );
@@ -313,7 +315,7 @@ fn main() -> Result<(), Report> {
         args.targets = vec![interface.cidr.clone()]
     }
 
-    print_args(&args);
+    print_args(&args, &interface);
 
     let (tx, rx) = mpsc::channel::<ScanMessage>();
 


### PR DESCRIPTION
Source IP was incorrectly using the base of the network instead of the actual IP address assigned to the targeted interface. This commit updates the generated NetworkInterface struct to hold the proper values for both cidr and ipv4, where ipv4 is the actual IP address assigned to the interface.