### PR TITLE
fix: improves log scrolling performance

### DIFF
--- a/term/src/main.rs
+++ b/term/src/main.rs
@@ -246,7 +246,9 @@ fn start_renderer_thread(
             Box::new(RendererSender::new(main_tx)),
             Box::new(RendererReceiver::new(renderer_rx)),
         );
-        let mut store = Store::new(initial_state, StoreReducer::boxed());
+        let mut reducer = StoreReducer::boxed();
+        reducer.enable_logging();
+        let mut store = Store::new(initial_state, reducer);
         store.set_sync_fn(move |a| {
             let _ = main_tx_clone.send(MainMessage::ActionSync(Box::new(
                 Action::Sync(Box::new(a)),

--- a/term/src/process/main/process.rs
+++ b/term/src/process/main/process.rs
@@ -70,11 +70,6 @@ impl MainProcess {
                     MainMessage::ArpUpdate(device) => {
                         self.store.dispatch(Action::AddDevice(device));
                     }
-                    MainMessage::ArpDone => {
-                        self.store.dispatch(Action::Log(
-                            "ARP scanning complete".into(),
-                        ));
-                    }
                     MainMessage::SynStart => {
                         self.store.dispatch(Action::UpdateMessage(Some(
                             "SYN scanning in progress...".into(),

--- a/term/src/process/renderer/process.rs
+++ b/term/src/process/renderer/process.rs
@@ -125,36 +125,53 @@ impl<B: Backend + std::io::Write> RendererProcess<B> {
             if let Ok(has_event) = event::poll(time::Duration::from_millis(16))
                 && has_event
             {
-                let evt = event::read()?;
-
-                if self.scroll_throttle.throttled(&evt) {
-                    continue;
+                // Drain all currently queued events before rendering.
+                // Without this, a trackpad swipe that generates dozens of
+                // scroll events causes one render per event, creating a
+                // multi-second backlog. By collecting everything that is
+                // already buffered we process the whole burst and render
+                // exactly once.
+                let mut events = vec![event::read()?];
+                while let Ok(true) = event::poll(time::Duration::ZERO) {
+                    events.push(event::read()?);
                 }
 
-                let ctx = CustomEventContext {
-                    state: &state,
-                    dispatcher: self.store.clone(),
-                    ipc: self.ipc.tx.clone(),
-                };
+                let mut need_render = false;
+                for evt in events {
+                    if self.scroll_throttle.throttled(&evt) {
+                        continue;
+                    }
 
-                // Process event through the application. We don't check the
-                // return value (whether event was handled) since we removed
-                // the 'q' key quit override. All quit operations now happen
-                // explicitly via ctrl-c or from within specific views.
-                self.app.process_event(&evt, &ctx)?;
-                // re-fetch state after event processing so render
-                // reflects any changes from dispatched actions
-                state = self.store.get_state();
-                self.render_frame(&state)?;
+                    let ctx = CustomEventContext {
+                        state: &state,
+                        dispatcher: self.store.clone(),
+                        ipc: self.ipc.tx.clone(),
+                    };
 
-                // do not allow overriding ctrl-c
-                if let CrossTermEvent::Key(key) = evt
-                    && key.kind == KeyEventKind::Press
-                    && key.code == KeyCode::Char('c')
-                    && key.modifiers == KeyModifiers::CONTROL
-                {
-                    self.ipc.tx.send(MainMessage::Quit(None))?;
-                    return Ok(());
+                    // Process event through the application. We don't check
+                    // the return value (whether event was handled) since we
+                    // removed the 'q' key quit override. All quit operations
+                    // now happen explicitly via ctrl-c or from within specific
+                    // views.
+                    self.app.process_event(&evt, &ctx)?;
+                    // re-fetch state after event processing so render
+                    // reflects any changes from dispatched actions
+                    state = self.store.get_state();
+                    need_render = true;
+
+                    // do not allow overriding ctrl-c
+                    if let CrossTermEvent::Key(key) = evt
+                        && key.kind == KeyEventKind::Press
+                        && key.code == KeyCode::Char('c')
+                        && key.modifiers == KeyModifiers::CONTROL
+                    {
+                        self.ipc.tx.send(MainMessage::Quit(None))?;
+                        return Ok(());
+                    }
+                }
+
+                if need_render {
+                    self.render_frame(&state)?;
                 }
             }
         }

--- a/term/src/process/renderer/scroll_throttle.rs
+++ b/term/src/process/renderer/scroll_throttle.rs
@@ -3,9 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, MouseEventKind};
 
-/// Default duration to throttle scroll events (arrow keys and vi-style j/k).
+/// Default duration to throttle scroll events (arrow keys, vi-style j/k, and
+/// mouse wheel / trackpad).
 const DEFAULT_SCROLL_THROTTLE_DURATION: Duration = Duration::from_millis(20);
 
 pub struct ScrollThrottle {
@@ -66,6 +67,7 @@ impl ScrollThrottle {
                 },
                 _ => false,
             },
+            Event::Mouse(m) => m.kind == MouseEventKind::ScrollUp,
             _ => false,
         }
     }
@@ -80,6 +82,7 @@ impl ScrollThrottle {
                 },
                 _ => false,
             },
+            Event::Mouse(m) => m.kind == MouseEventKind::ScrollDown,
             _ => false,
         }
     }

--- a/term/src/process/renderer/scroll_throttle_tests.rs
+++ b/term/src/process/renderer/scroll_throttle_tests.rs
@@ -1,9 +1,19 @@
 use ratatui::crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+    MouseEvent, MouseEventKind,
 };
 use std::{thread, time::Duration};
 
 use super::ScrollThrottle;
+
+fn mouse_scroll_event(kind: MouseEventKind) -> Event {
+    Event::Mouse(MouseEvent {
+        kind,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+}
 
 fn key_event(code: KeyCode) -> Event {
     Event::Key(KeyEvent {
@@ -122,6 +132,36 @@ fn custom_throttle_duration_is_respected() {
     // Go past throttle to deal with imprecise runners
     thread::sleep(Duration::from_millis(1000));
     assert!(!throttle.throttled(&key_event(KeyCode::Down)));
+}
+
+#[test]
+fn mouse_scroll_up_is_throttled() {
+    let throttle = ScrollThrottle::new(Duration::from_millis(50));
+
+    // First mouse scroll up is not throttled
+    assert!(!throttle.throttled(&mouse_scroll_event(MouseEventKind::ScrollUp)));
+
+    // Rapid subsequent events are throttled
+    assert!(throttle.throttled(&mouse_scroll_event(MouseEventKind::ScrollUp)));
+    assert!(throttle.throttled(&key_event(KeyCode::Up)));
+    assert!(throttle.throttled(&key_event(KeyCode::Char('k'))));
+}
+
+#[test]
+fn mouse_scroll_down_is_throttled() {
+    let throttle = ScrollThrottle::new(Duration::from_millis(50));
+
+    // First mouse scroll down is not throttled
+    assert!(
+        !throttle.throttled(&mouse_scroll_event(MouseEventKind::ScrollDown))
+    );
+
+    // Rapid subsequent events are throttled
+    assert!(
+        throttle.throttled(&mouse_scroll_event(MouseEventKind::ScrollDown))
+    );
+    assert!(throttle.throttled(&key_event(KeyCode::Down)));
+    assert!(throttle.throttled(&key_event(KeyCode::Char('j'))));
 }
 
 #[test]

--- a/term/src/store/action.rs
+++ b/term/src/store/action.rs
@@ -15,7 +15,6 @@ use crate::{
 pub enum Action {
     SetUIPaused(bool),
     SetError(Option<String>),
-    Log(String),
     SetCommandInProgress(Option<Command>),
     UpdateCommandOutput((Command, Output)),
     ClearCommandOutput,

--- a/term/src/store/reducer.rs
+++ b/term/src/store/reducer.rs
@@ -10,17 +10,25 @@ mod reducers;
 
 /// Applies actions to state, producing new state and optional side effects.
 #[derive(Default)]
-pub struct StoreReducer;
+pub struct StoreReducer {
+    logging_enabled: bool,
+}
 
 impl StoreReducer {
     pub fn boxed() -> Box<Self> {
         Box::default()
     }
 
+    pub fn enable_logging(&mut self) {
+        self.logging_enabled = true;
+    }
+
     fn log_action<D: Debug>(&self, name: &str, data: &D, state: &mut State) {
-        state
-            .logs
-            .push_back(format!("processing action: {name}({:?})", data));
+        if self.logging_enabled {
+            state
+                .logs
+                .push_back(format!("processing action: {name}({:?})", data));
+        }
     }
 }
 
@@ -37,13 +45,6 @@ impl Reducer for StoreReducer {
             Action::SetError(err) => {
                 self.log_action("SetError", &err, state);
                 reducers::ui::set_error(state, err);
-            }
-            Action::Log(log) => {
-                log::debug!("{log}");
-                if state.logs.len() == state.logs.capacity() {
-                    state.logs.pop_front();
-                }
-                state.logs.push_back(log);
             }
             Action::UpdateMessage(message) => {
                 self.log_action("UpdateMessage", &message, state);

--- a/term/src/store/reducer_tests.rs
+++ b/term/src/store/reducer_tests.rs
@@ -20,7 +20,7 @@ use super::Reducer;
 
 fn setup() -> (State, StoreReducer) {
     let state = State::default();
-    (state, StoreReducer)
+    (state, StoreReducer::default())
 }
 
 #[test]

--- a/term/src/ui/views/logs_tests.rs
+++ b/term/src/ui/views/logs_tests.rs
@@ -9,10 +9,12 @@ use crate::store::{
 use super::*;
 
 fn setup() -> (LogsView, Store) {
-    let store = Store::new(State::default(), StoreReducer::boxed());
+    let mut reducer = StoreReducer::boxed();
+    reducer.enable_logging();
+    let store = Store::new(State::default(), reducer);
 
-    store.dispatch(Action::Log("test log 1".into()));
-    store.dispatch(Action::Log("test log 2".into()));
+    store.dispatch(Action::UpdateMessage(Some("test message 1".into())));
+    store.dispatch(Action::UpdateMessage(Some("test message 2".into())));
 
     (LogsView::new(), store)
 }

--- a/term/src/ui/views/snapshots/r_lanterm__ui__views__logs__tests__logs_view.snap
+++ b/term/src/ui/views/snapshots/r_lanterm__ui__views__logs__tests__logs_view.snap
@@ -3,9 +3,9 @@ source: term/src/ui/views/./logs_tests.rs
 expression: terminal.backend()
 ---
 "                                                                                                                                  "
-"test log 1                                                                                                                        "
+"processing action: UpdateMessage(Some("test message 1"))                                                                          "
 "                                                                                                                                █ "
-"test log 2                                                                                                                      █ "
+"processing action: UpdateMessage(Some("test message 2"))                                                                        █ "
 "                                                                                                                                █ "
 "                                                                                                                                █ "
 "                                                                                                                                █ "


### PR DESCRIPTION
Rather than processing each terminal event, key presses, scroll events etc, one at a time - one per render frame - we now drain the event queue and process them all at once and render once. This prevents a large backlog of events which bogs down the render loop and causes it to appear unresponsive